### PR TITLE
duplicate http headers

### DIFF
--- a/httpheader.php
+++ b/httpheader.php
@@ -97,8 +97,10 @@ class PlgSystemHttpHeader extends CMSPlugin
 	public function onAfterInitialise()
 	{
 		// Set the default header when they are enabled
-		$this->setStaticHeaders();
-
+		if ((int) $this->params->get('write_static_headers', 0) == 0)
+		{ 
+			$this->setStaticHeaders();
+		}
 		// Handle CSP Header configuration
 		$cspOptions = (int) $this->params->get('contentsecuritypolicy', 0);
 


### PR DESCRIPTION
When "write header to config file" is set, security headers are created twice : once in .htaccess/web.config file and once in html code.